### PR TITLE
fix(auth): change cookie sameSite from strict to lax for OAuth compatibility

### DIFF
--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -8,7 +8,7 @@ const JWT_COOKIE_NAME = "auth_token";
 const COOKIE_OPTIONS = {
 	httpOnly: true,
 	secure: process.env["NODE_ENV"] === "production",
-	sameSite: "strict" as const,
+	sameSite: "lax" as const,
 	maxAge: 60 * 60 * 24 * 7, // 7 days
 	path: "/",
 };


### PR DESCRIPTION
## Summary
- Changed JWT cookie `sameSite` setting from `strict` to `lax` in authentication middleware
- Fixes mobile user authentication failure after Foursquare OAuth callback

## Problem
Mobile users reported receiving `{"error": "Authentication required"}` (JSON format) after completing Foursquare OAuth flow. This occurred because:
- `sameSite: "strict"` blocks cookies on cross-site redirects
- OAuth callback from foursquare.com → our app is treated as cross-site navigation
- Mobile browsers enforce this more strictly (especially with app switching)

## Solution
Changed to `sameSite: "lax"` which:
- ✅ Allows cookies on top-level GET navigation (OAuth callbacks work)
- ✅ Maintains CSRF protection (OAuth state parameter validation still active)
- ✅ Follows OAuth industry standard (Discord, GitHub, etc. use lax)
- ✅ Compatible with future SPA dashboard (same-origin API calls work identically)

## Security Impact
- **CSRF Risk**: Minimal - still protected by OAuth state parameter validation
- **Best Practice**: `lax` is recommended for OAuth flows by OWASP

## Test Plan
- [ ] Deploy to production
- [ ] Test Foursquare OAuth flow on mobile (iOS Safari, Android Chrome)
- [ ] Verify cookie is preserved through callback redirect
- [ ] Confirm successful account linking

🤖 Generated with [Claude Code](https://claude.com/claude-code)